### PR TITLE
fix(boot): NVIDIA RTX 40xx black screen + debug entry + Ventoy log dumping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,14 +39,9 @@ release/*.fd
 release/OVMF_VARS.fd
 release/vmshare/
 
-# ── ISO build outputs ──────────────────────────────────────
-src/iso/prebuilt/
-src/iso/pacman-cache/
-src/iso/offline-repo/*.pkg.tar.*
-src/iso/offline-repo/*.db
-src/iso/offline-repo/*.db.tar.*
-src/iso/offline-repo/*.files
-src/iso/offline-repo/*.files.tar.*
+# ── Build outputs (written outside src/ to keep source tree clean) ────────
+build/prebuilt/
+build/target/
 *.iso
 
 # ── Caches ──────────────────────────────────────────────────

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -6,9 +6,198 @@ How to extend, modify, and contribute to smplOS.
 
 ## Table of Contents
 
+- [How the Build Works](#how-the-build-works)
 - [Development Iteration](#development-iteration)
 - [VM Testing](#vm-testing)
 - [Adding a Settings Entry](#adding-a-settings-entry)
+
+---
+
+## How the Build Works
+
+Running `./src/build-iso.sh` produces a bootable Arch-based ISO. The whole thing is
+containerized for reproducibility — you don't need an Arch host and your system never
+gets touched.
+
+### Two-Stage Container Architecture
+
+The build uses **two separate Podman containers** in sequence.
+
+```
+build-iso.sh  (host orchestrator)
+│
+├─ Stage 1 ─ AUR builder container  (archlinux:latest)
+│             Builds AUR packages that can't be fetched from official repos.
+│             Output: .pkg.tar.zst files → build/prebuilt/
+│             Skipped automatically if all packages already exist there.
+│
+└─ Stage 2 ─ ISO builder container  (archlinux:latest, --privileged)
+              Downloads all packages, compiles Rust apps, runs mkarchiso.
+              Output: .iso → release/
+```
+
+**Why `sudo podman`?** `mkarchiso` (the Arch ISO tool) requires real root to create
+loop devices, run `mount`, and call `mksquashfs`. Rootless Podman's `--privileged`
+only grants unprivileged-user capabilities, which isn't enough. So the outer script
+runs the container with `sudo podman run --privileged`, but Podman itself requires no
+daemon or background service.
+
+**Why two containers?** AUR packages (eww, brave-bin, paru-bin, etc.) must be compiled
+with `makepkg` as a non-root user, which is incompatible with the `--privileged` ISO
+builder. Separating them also means you only rebuild AUR packages when their
+`PKGBUILD` changes — subsequent runs reuse the cached `.pkg.tar.zst` files in
+`build/prebuilt/`.
+
+---
+
+### Stage 1: AUR Package Builder
+
+Triggered by: `build_missing_aur_packages()` in `src/build-iso.sh`
+
+For each AUR package listed in `packages-aur.txt`:
+1. Checks `build/prebuilt/` for an existing `<pkg>-*.pkg.tar.zst` — **skips if found**.
+2. Spins up a fresh `archlinux:latest` container (no `--privileged`, `--network=host`).
+3. Creates a non-root `builder` user, clones the AUR git repo, imports required PGP
+   keys, and runs `makepkg -s`.
+4. Copies the resulting `.pkg.tar.zst` to `/output`, which is bind-mounted to
+   `build/prebuilt/` on the host.
+
+If any package needs Rust (e.g. `eww`), `rustup` is installed inside the container
+before building.
+
+---
+
+### Stage 2: ISO Builder Container
+
+Triggered by: `run_build()` in `src/build-iso.sh`
+
+The container runs `src/builder/build.sh` as root inside `archlinux:latest
+--privileged`. Volume mounts wired in from the host:
+
+| Host path | Container path | Access |
+|---|---|---|
+| `src/` | `/build/src` | read-only |
+| `release/` | `/build/release` | read-write (ISO lands here) |
+| `build/prebuilt/` | `/build/prebuilt` | read-only (AUR .pkg.tar.zst) |
+| `.cache/build_YYYY-MM-DD/pacman/` | `/var/cache/smplos/pacman-cache` | read-write |
+| `.cache/build_YYYY-MM-DD/offline-repo/` | `/var/cache/smplos/mirror/offline` | read-write |
+| `.cache/binaries/` | `/var/cache/smplos/binaries` | read-write (Rust binary cache) |
+| `/var/cache/pacman/pkg/` *(Arch hosts only)* | `/var/cache/pacman/pkg` | read-only (speeds up downloads) |
+
+The build script inside the container runs these stages in order:
+
+```
+setup_build_env       → set paths, parse env vars
+collect_packages      → merge shared + compositor + edition package lists
+setup_profile         → populate the mkarchiso profile directory
+download_packages     → pacstrap ~875 packages into the airootfs
+process_aur_packages  → install prebuilt .pkg.tar.zst from /build/prebuilt
+download_flatpaks     → (optional) write Flathub install list
+download_appimages    → (optional) download AppImages
+create_repo_database  → build a local pacman repo from the offline mirror
+setup_pacman_conf     → write pacman.conf for the ISO environment
+update_package_list   → generate profiledef package list for mkarchiso
+update_profiledef     → set ISO name, version, compression
+setup_airootfs        → copy dotfiles, configs, scripts, themes, installer
+build_st              → compile st (suckless terminal) from source
+build_notif_center    → compile notif-center (Rust+Slint)
+build_kb_center       → compile kb-center (Rust+Slint)
+build_disp_center     → compile disp-center (Rust+Slint)
+build_app_center      → compile app-center (Rust+Slint)
+setup_boot            → write systemd-boot + GRUB loopback + Syslinux configs
+build_iso             → run mkarchiso → xorriso → .iso
+```
+
+---
+
+### Rust App Compilation (inside the container)
+
+The four Rust/Slint GUI apps (`notif-center`, `kb-center`, `disp-center`,
+`app-center`) are compiled from source **inside the ISO builder container**, not on
+the host. Each follows the same pattern:
+
+1. **Source-hash cache check** — hashes all `.rs` files, `Cargo.toml`, `Cargo.lock`,
+   and `build.rs`. If the hash matches a file in `/var/cache/smplos/binaries/`, the
+   cached binary is reused and the Rust compile is skipped entirely. This makes
+   repeated builds fast when the Rust source hasn't changed.
+2. **Copy to temp dir** — source is copied to `/tmp/<app>-build/` so the build never
+   touches the read-only `/build/src` mount.
+3. **`cargo build --release`** — compiled inside the temp dir.
+4. **Install + strip** — binary installed to both `/usr/local/bin/` (for the live ISO
+   session) and `/root/smplos/bin/` (for the post-install deployer).
+5. **Cache** — binary saved to `/var/cache/smplos/binaries/<app>-<hash>` for future runs.
+
+The `/var/cache/smplos/binaries/` path inside the container is bind-mounted from
+`.cache/binaries/` on the host, so the cache persists across builds.
+
+---
+
+### Artifact Locations
+
+All build output lands **outside `src/`** — the source tree stays clean:
+
+| What | Where |
+|---|---|
+| **Final ISO** | `release/smplos-hyprland-YYMMDD-HHmm.iso` |
+| **AUR packages** | `build/prebuilt/*.pkg.tar.zst` |
+| **Rust binary cache** | `.cache/binaries/<app>-<src-hash>` |
+| **Pacman package cache** | `.cache/build_YYYY-MM-DD/pacman/` (dated, kept 3 days) |
+| **Offline repo mirror** | `.cache/build_YYYY-MM-DD/offline-repo/` (dated, kept 3 days) |
+| **Build logs** | `.cache/logs/build-YYYYMMDD-HHMMSS.log` |
+
+The `build/` and `.cache/` directories are git-ignored. `release/` contains only the
+ISO and the helper scripts that ship with the project (`test-iso.sh`, `dev-push.sh`,
+etc.) — only `.iso` files are git-ignored there.
+
+For **local development builds** of the Rust apps (running `build.sh` directly on
+your host without going through the container), `cargo` output goes to
+`build/target/` via `CARGO_TARGET_DIR` — not into `src/shared/<app>/target/`.
+
+---
+
+### Log Files
+
+Every run writes a timestamped log to `.cache/logs/`:
+
+```
+.cache/logs/
+└── build-20260222-104400.log   ← stdout + stderr of the entire build
+```
+
+The log is written by `exec > >(tee -a "$BUILD_LOG") 2>&1` at the top of
+`build-iso.sh`, so output goes to **both the terminal and the log file
+simultaneously**, without any external pipe. This means you can safely run the build
+in the background (`bash src/build-iso.sh & disown`) and tail the log separately:
+
+```bash
+# Start build in background
+cd ~/Documents/sources/smplos
+bash src/build-iso.sh &
+
+# Follow the log without interfering with the build process
+tail -f .cache/logs/build-$(ls -t .cache/logs/ | head -1)
+```
+
+To scan a completed log for errors:
+
+```bash
+grep -E "ERROR|FAILED|error:|die" .cache/logs/build-*.log | cat
+```
+
+Logs older than the three most recent dated cache directories are pruned automatically
+on each build run.
+
+---
+
+### Caching and Re-runs
+
+| Scenario | What gets reused |
+|---|---|
+| Same day, nothing changed | AUR packages, Rust binaries, downloaded `.pkg` files |
+| New day, same packages | AUR packages, Rust binaries (new dated pacman cache) |
+| AUR package already in `build/prebuilt/` | Skipped, container never spawned |
+| Rust source unchanged (same hash) | Cached binary from `.cache/binaries/` |
+| `--no-cache` flag | Forces fresh package downloads |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -175,22 +175,60 @@ smplOS separates shared infrastructure from compositor-specific config. The goal
 
 ```
 src/
-  shared/              Everything here works on ALL compositors
-    bin/               User-facing scripts (installed to /usr/local/bin/)
-    eww/               EWW bar and widgets (GTK3 - works on X11 + Wayland)
-    configs/smplos/    Cross-compositor configs (bindings.conf, branding)
-    themes/            14 themes with templates for all apps
-    installer/         OS installer
-    start-menu/        Start menu launcher (Rust + Slint)
-    app-center/        App center for installing/managing apps (Rust + Slint)
-    webapp-center/     Web app manager (Rust + Slint)
+  build-iso.sh              Entry point — detects Docker, launches builder
+  bootstrap.sh              One-shot host bootstrap (installs Docker if absent)
+  generate-theme-configs.sh Re-generates pre-baked theme configs from colors.toml templates
+
+  shared/                   Everything here works on ALL compositors
+    bin/                    User-facing scripts (installed to /usr/local/bin/)
+    eww/                    EWW bar and widgets (GTK3 — works on X11 + Wayland)
+    configs/
+      smplos/               Cross-compositor configs (bindings.conf, messengers.conf, branding)
+      <app>/                Per-app default configs (btop, dunst, fish, foot, nvim, …)
+    themes/                 14 themes — each a self-contained directory with pre-baked configs
+    icons/                  SVG status icon templates (baked with accent colors by theme-set)
+    applications/           Shared web-app .desktop entries and hicolor icons
+    skel/                   Default user home skeleton (copied to /etc/skel in the ISO)
+    system/                 System-level files (os-release, …)
+    start-menu/             Start menu launcher (Rust + Slint)
+    app-center/             App center — install/manage packages (Rust + Slint)
+    notif-center/           Notification center — dunst history viewer (Rust + Slint)
+    disp-center/            Display manager — monitor layout/resolution (Rust + Slint)
+    kb-center/              Keyboard manager — layouts, repeat rate (Rust + Slint)
+    webapp-center/          Web app manager — sandboxed browser shortcuts (Rust + Slint)
+    packages.txt            Shared package list (all compositors)
+    packages-aur.txt        AUR packages (prebuilt, injected into offline mirror)
+    packages-flatpak.txt    Flatpak apps (installed on first boot)
+    packages-appimage.txt   AppImages (bundled into the ISO)
+
   compositors/
-    hyprland/          Hyprland-specific config (hypr/, st-wl terminal)
-    dwm/               DWM-specific config (st terminal, future)
-  editions/            Edition-specific package lists and post-install scripts
-  builder/             ISO build pipeline
-  iso/                 ISO resources (boot entries, offline repo)
-release/               VM testing tools (dev-push, test-iso, QEMU scripts)
+    hyprland/               Hyprland-specific config
+      hypr/                 hyprland.conf (sources shared bindings.conf)
+      configs/              Hyprland-only app configs (hyprlock, hyprpaper, …)
+      st/                   st-wl patched terminal (config.def.h, patches.def.h)
+      packages.txt          Wayland-specific packages
+      postinstall.sh        Hyprland post-install steps
+    dwm/                    DWM-specific config (X11, planned)
+      st/                   st patched terminal
+      packages.txt          X11-specific packages
+      postinstall.sh        DWM post-install steps
+
+  editions/                 Optional edition overlays (stack on top of base)
+    lite/                   Lite edition — reduced package set
+    productivity/           Productivity — Logseq, LibreOffice, KeePassXC
+    creators/               Creators — OBS, Kdenlive, GIMP
+    communication/          Communication — Discord, Signal, Slack
+    development/            Development — VSCode, LazyVim, lazygit
+    ai/                     AI — Ollama, open-webui
+
+  installer/                smplOS interactive installer (smplos-install)
+  builder/                  ISO build pipeline (runs inside Docker/Podman)
+  custom-pkgbuilds/         In-tree PKGBUILDs for packages not in AUR
+  iso/                      ISO resources (offline repo metadata, QEMU boot script)
+
+release/                    VM testing tools (dev-push.sh, dev-apply.sh, test-iso.sh, QEMU scripts)
+build/
+  prebuilt/                 Pre-compiled AUR packages (.pkg.tar.zst) bundled into the ISO
 ```
 
 ## Design Principles
@@ -315,7 +353,7 @@ Terminal auto-detection makes sure it works regardless of which terminal is inst
 
 ## Building
 
-The build system is designed to work on **first run, on any Linux distro**. It runs inside a Docker container for reproducibility - your host system only needs Docker.
+The build system is designed to work on **first run, on any Linux distro**. It runs inside an Arch Linux container for reproducibility. The only host requirement is a container runtime — **Podman** (preferred, daemonless) or **Docker**.
 
 ### Quick Start
 
@@ -327,23 +365,22 @@ This produces a bootable Arch Linux ISO in `release/`. First build takes ~15-20 
 
 ### Prerequisites
 
-The only hard requirement is **Docker**. If Docker isn't installed, the build script will detect your distro and offer to install it for you:
+**Podman** is the preferred container runtime — it's daemonless and needs no background service. **Docker** works too and is auto-detected as a fallback.
+
+If neither is installed, the build script will offer to install Podman automatically:
 
 ```
-[WARN] Docker not found
-Install Docker automatically? [Y/n]
+[WARN] No container runtime found (podman or docker)
+Install Podman automatically? [Y/n]
 ```
 
-If you prefer to install Docker yourself:
+To install Podman manually:
 
 <details>
 <summary><b>Arch / EndeavourOS / Manjaro / Garuda / CachyOS</b></summary>
 
 ```bash
-sudo pacman -S --needed docker
-sudo systemctl enable --now docker
-sudo usermod -aG docker $USER
-# Log out and back in for group to take effect
+sudo pacman -S --needed podman
 ```
 </details>
 
@@ -351,27 +388,7 @@ sudo usermod -aG docker $USER
 <summary><b>Ubuntu / Debian / Pop!_OS / Linux Mint / Zorin</b></summary>
 
 ```bash
-# Install prerequisites
-sudo apt-get update
-sudo apt-get install -y ca-certificates curl gnupg
-
-# Add Docker GPG key
-sudo install -m 0755 -d /etc/apt/keyrings
-curl -fsSL https://download.docker.com/linux/ubuntu/gpg \
-    | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
-sudo chmod a+r /etc/apt/keyrings/docker.gpg
-
-# Add Docker repo (use "ubuntu" or "debian" depending on your base)
-echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] \
-    https://download.docker.com/linux/ubuntu \
-    $(. /etc/os-release && echo "$VERSION_CODENAME") stable" \
-    | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
-
-# Install
-sudo apt-get update
-sudo apt-get install -y docker-ce docker-ce-cli containerd.io
-sudo systemctl enable --now docker
-sudo usermod -aG docker $USER
+sudo apt-get update && sudo apt-get install -y podman
 ```
 </details>
 
@@ -379,9 +396,7 @@ sudo usermod -aG docker $USER
 <summary><b>Fedora / Nobara</b></summary>
 
 ```bash
-sudo dnf install -y docker
-sudo systemctl enable --now docker
-sudo usermod -aG docker $USER
+sudo dnf install -y podman
 ```
 </details>
 
@@ -389,9 +404,7 @@ sudo usermod -aG docker $USER
 <summary><b>openSUSE</b></summary>
 
 ```bash
-sudo zypper install -y docker
-sudo systemctl enable --now docker
-sudo usermod -aG docker $USER
+sudo zypper install -y podman
 ```
 </details>
 
@@ -399,29 +412,28 @@ sudo usermod -aG docker $USER
 <summary><b>Void Linux</b></summary>
 
 ```bash
-sudo xbps-install -y docker
-sudo ln -s /etc/sv/docker /var/service/
-sudo usermod -aG docker $USER
+sudo xbps-install -y podman
 ```
 </details>
 
-After installing Docker, **log out and back in** so the docker group takes effect. If you skip this, the build script will automatically fall back to `sudo docker`.
+> **No group setup needed.** The build script runs `sudo podman` automatically — `mkarchiso` requires real root for loop devices and mounts, so there's no rootless option regardless of runtime.
 
 You also need **~10 GB of free disk space**. The script checks this and warns you if you're low.
 
 ### Build Options
 
 ```
-Usage: build-iso.sh [OPTIONS]
+Usage: build-iso.sh [EDITIONS...] [OPTIONS]
 
 Editions (stackable):
-    -p, --productivity      Add Productivity edition (Logseq, LibreOffice, KeePassXC)
-    -c, --creators          Add Creators edition (OBS, Kdenlive, GIMP)
-    -m, --communication     Add Communication edition (Discord, Signal, Slack)
-    -d, --development       Add Development edition (VSCode, LazyVim, lazygit)
-    -a, --ai                Add AI edition (Ollama, open-webui)
+    -p, --productivity      Office & workflow (Logseq, LibreOffice, KeePassXC)
+    -c, --creators          Design & media (OBS, Kdenlive, GIMP)
+    -m, --communication     Chat & calls (Discord, Signal, Slack)
+    -d, --development       Developer tools (VSCode, LazyVim, lazygit)
+    -a, --ai                AI tools (Ollama, open-webui)
+    --all                   All editions (equivalent to -p -c -m -d -a)
 
-General:
+Options:
     --compositor NAME       Compositor to build (hyprland, dwm) [default: hyprland]
     -r, --release           Release build: max xz compression (slow, smallest ISO)
     -n, --no-cache          Force fresh package downloads
@@ -441,14 +453,14 @@ General:
 # Productivity + Development
 ./build-iso.sh -p -d
 
-# Stack everything
-./build-iso.sh -p -d -c -m -a
+# All editions
+./build-iso.sh --all
 
-# Fast iteration build (skip AUR packages like EWW that take ages to compile)
+# Fast iteration (skip AUR packages like EWW that take ages to compile)
 ./build-iso.sh --skip-aur
 
 # Release build with max compression
-./build-iso.sh -p -d --release
+./build-iso.sh --all --release
 
 # Full verbose output for debugging
 ./build-iso.sh -v
@@ -456,12 +468,12 @@ General:
 
 ### What the Build Does
 
-1. **Checks prerequisites** - detects your distro, ensures Docker is installed and running, checks disk space.
-2. **Builds AUR packages** (unless `--skip-aur`) - compiles packages like EWW in a temporary container. Results are cached in `src/iso/prebuilt/` so they only build once.
+1. **Checks prerequisites** - detects your distro, ensures Podman (or Docker) is installed, checks disk space, pre-authenticates `sudo`.
+2. **Builds AUR packages** (unless `--skip-aur`) - compiles packages like EWW in a temporary container. Results are cached in `build/prebuilt/` so they only build once.
 3. **Pulls `archlinux:latest`** - the build runs in a fresh Arch container for reproducibility.
-4. **Downloads packages** - uses `pacman -Syw` to download all packages into a local mirror. On Arch-based hosts, your system's pacman cache is mounted read-only for instant hits.
+4. **Downloads packages** - pacman downloads all packages into a dated local mirror. On Arch-based hosts, your system's pacman cache is mounted read-only for instant hits.
 5. **Builds the ISO** - copies configs, themes, scripts, and the offline package mirror into an Arch ISO profile, then runs `mkarchiso`.
-6. **Outputs** - the final `.iso` lands in `release/`.
+6. **Outputs** - the final `.iso` lands in `release/`. The full build log is saved to `.cache/logs/build-TIMESTAMP.log`.
 
 ### Caching
 
@@ -475,11 +487,12 @@ Builds use a **dated cache** (`build_YYYY-MM-DD/`) under `.cache/`. Same-day reb
 
 | Problem | Solution |
 |---------|----------|
-| `permission denied` from Docker | Run `sudo usermod -aG docker $USER`, then log out and back in |
-| DNS errors inside container | The build script passes `--dns 1.1.1.1 --dns 8.8.8.8` to work around systemd-resolved. If you still get DNS errors, check your firewall. |
-| `no space left on device` | Need ~10 GB free. Also run `docker system prune` to reclaim Docker disk space. |
-| AUR build fails | Try `--skip-aur` to skip it. Pre-built AUR packages are cached in `src/iso/prebuilt/`. |
-| Slow builds | First build downloads ~2 GB of packages. After that, the cache makes rebuilds much faster. On Arch hosts, your system pacman cache is reused automatically. |
+| `sudo` password prompt mid-build | Expected — `mkarchiso` needs real root for loop devices and mounts. The script pre-authenticates `sudo` at startup and keeps it alive throughout the build. |
+| DNS errors inside container | The build uses `--network=host`, so the container shares your host's network stack. If you still get DNS errors, check that your host can reach `archlinux.org` and that your firewall allows container traffic. |
+| `no space left on device` | Need ~10 GB free. Run `podman system prune` (or `docker system prune`) to reclaim container disk space. |
+| AUR build fails | Try `--skip-aur` to skip it. Pre-built AUR packages are cached in `build/prebuilt/` and reused on the next run. |
+| Slow builds | First build downloads ~2 GB of packages. After that, the dated cache makes same-day rebuilds much faster. On Arch hosts, your system pacman cache is reused automatically. |
+| Build log | All output is automatically saved to `.cache/logs/build-TIMESTAMP.log` for post-mortem inspection. |
 
 ### Development & Testing
 

--- a/README.md
+++ b/README.md
@@ -224,7 +224,6 @@ src/
   installer/                smplOS interactive installer (smplos-install)
   builder/                  ISO build pipeline (runs inside Docker/Podman)
   custom-pkgbuilds/         In-tree PKGBUILDs for packages not in AUR
-  iso/                      ISO resources (offline repo metadata, QEMU boot script)
 
 release/                    VM testing tools (dev-push.sh, dev-apply.sh, test-iso.sh, QEMU scripts)
 build/

--- a/src/build-iso.sh
+++ b/src/build-iso.sh
@@ -14,6 +14,12 @@ LOG_DIR="$PROJECT_ROOT/.cache/logs"
 mkdir -p "$LOG_DIR"
 BUILD_LOG="$LOG_DIR/build-$(date +%Y%m%d-%H%M%S).log"
 
+# Tee all output (stdout + stderr) to the log file AND the terminal for the
+# entire script lifetime.  Using exec here avoids the external pipe approach
+# (./build-iso.sh | tee ...) which gets killed by SIGINT when you run any
+# monitoring command in the same terminal session.
+exec > >(tee -a "$BUILD_LOG") 2>&1
+
 # Colors
 RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'
 BLUE='\033[0;34m'; BOLD='\033[1m'; NC='\033[0m'
@@ -215,7 +221,7 @@ check_prerequisites() {
 ###############################################################################
 
 build_missing_aur_packages() {
-    local prebuilt_dir="$SCRIPT_DIR/iso/prebuilt"
+    local prebuilt_dir="$PROJECT_ROOT/build/prebuilt"
     mkdir -p "$prebuilt_dir"
 
     # Collect AUR package names from all package lists
@@ -349,7 +355,7 @@ run_build() {
             | sort | head -n -3 | xargs -r rm -rf
     fi
 
-    local prebuilt_dir="$SCRIPT_DIR/iso/prebuilt"
+    local prebuilt_dir="$PROJECT_ROOT/build/prebuilt"
 
     local run_args=(
         --rm --privileged

--- a/src/shared/app-center/build.sh
+++ b/src/shared/app-center/build.sh
@@ -9,6 +9,12 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$SCRIPT_DIR"
 
+# Redirect cargo output outside the source tree so src/ stays clean.
+# PROJECT_ROOT is 3 levels up: app-center/ -> shared/ -> src/ -> project root
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+export CARGO_TARGET_DIR="$PROJECT_ROOT/build/target"
+mkdir -p "$CARGO_TARGET_DIR"
+
 if ! command -v pacman >/dev/null 2>&1; then
   echo "Error: this script is intended for Arch Linux (pacman not found)." >&2
   exit 1
@@ -62,7 +68,7 @@ install_missing_pkgs "runtime dependencies" "${RUNTIME_PKGS[@]}"
 echo "==> Building app-center (release)..."
 cargo build --release
 
-BIN_PATH="$SCRIPT_DIR/target/release/app-center"
+BIN_PATH="$CARGO_TARGET_DIR/release/app-center"
 if [[ ! -x "$BIN_PATH" ]]; then
   echo "Error: build finished but binary not found at $BIN_PATH" >&2
   exit 1

--- a/src/shared/disp-center/build.sh
+++ b/src/shared/disp-center/build.sh
@@ -9,6 +9,12 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$SCRIPT_DIR"
 
+# Redirect cargo output outside the source tree so src/ stays clean.
+# PROJECT_ROOT is 3 levels up: disp-center/ -> shared/ -> src/ -> project root
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+export CARGO_TARGET_DIR="$PROJECT_ROOT/build/target"
+mkdir -p "$CARGO_TARGET_DIR"
+
 if ! command -v pacman >/dev/null 2>&1; then
   echo "Error: this script is intended for Arch Linux (pacman not found)." >&2
   exit 1
@@ -54,7 +60,7 @@ install_missing_pkgs "build dependencies" "${ARCH_PKGS[@]}"
 echo "==> Building disp-center (release)..."
 cargo build --release
 
-BIN_PATH="$SCRIPT_DIR/target/release/disp-center"
+BIN_PATH="$CARGO_TARGET_DIR/release/disp-center"
 if [[ ! -x "$BIN_PATH" ]]; then
   echo "Error: build finished but binary not found at $BIN_PATH" >&2
   exit 1

--- a/src/shared/kb-center/build.sh
+++ b/src/shared/kb-center/build.sh
@@ -9,6 +9,12 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$SCRIPT_DIR"
 
+# Redirect cargo output outside the source tree so src/ stays clean.
+# PROJECT_ROOT is 3 levels up: kb-center/ -> shared/ -> src/ -> project root
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+export CARGO_TARGET_DIR="$PROJECT_ROOT/build/target"
+mkdir -p "$CARGO_TARGET_DIR"
+
 if ! command -v pacman >/dev/null 2>&1; then
   echo "Error: this script is intended for Arch Linux (pacman not found)." >&2
   exit 1
@@ -54,7 +60,7 @@ install_missing_pkgs "build dependencies" "${ARCH_PKGS[@]}"
 echo "==> Building kb-center (release)..."
 cargo build --release
 
-BIN_PATH="$SCRIPT_DIR/target/release/kb-center"
+BIN_PATH="$CARGO_TARGET_DIR/release/kb-center"
 if [[ ! -x "$BIN_PATH" ]]; then
   echo "Error: build finished but binary not found at $BIN_PATH" >&2
   exit 1

--- a/src/shared/notif-center/build.sh
+++ b/src/shared/notif-center/build.sh
@@ -9,6 +9,12 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$SCRIPT_DIR"
 
+# Redirect cargo output outside the source tree so src/ stays clean.
+# PROJECT_ROOT is 3 levels up: notif-center/ -> shared/ -> src/ -> project root
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+export CARGO_TARGET_DIR="$PROJECT_ROOT/build/target"
+mkdir -p "$CARGO_TARGET_DIR"
+
 if ! command -v pacman >/dev/null 2>&1; then
   echo "Error: this script is intended for Arch Linux (pacman not found)." >&2
   exit 1
@@ -61,7 +67,7 @@ install_missing_pkgs "runtime dependencies" "${RUNTIME_PKGS[@]}"
 echo "==> Building notif-center (release)..."
 cargo build --release
 
-BIN_PATH="$SCRIPT_DIR/target/release/notif-center"
+BIN_PATH="$CARGO_TARGET_DIR/release/notif-center"
 if [[ ! -x "$BIN_PATH" ]]; then
   echo "Error: build finished but binary not found at $BIN_PATH" >&2
   exit 1


### PR DESCRIPTION
## Problem

Booting the ISO from Ventoy on a machine with an **NVIDIA RTX 4060 Ti (Ada Lovelace / AD106)** results in a black screen followed by an immediate return to the Ventoy menu. The `nouveau` open-source driver attempts KMS initialisation on Ada Lovelace hardware, fails silently (hidden by `quiet splash`), and causes EFI to return control to Ventoy.

## Changes

### 🐛 Fix: `nouveau.modeset=0` on all default boot entries
Added to the default kernel cmdline in systemd-boot, GRUB `loopback.cfg`, and syslinux. Prevents `nouveau` from taking over the display; the EFI framebuffer (`simpledrm`) handles it instead. No-op on Intel/AMD hardware.

### 🔍 New: `smplOS (Debug)` boot entry (all 3 bootloaders)
A dedicated debug entry that:
- Strips `quiet`, `splash`, `plymouth` — raw kernel messages visible on screen
- Enables `rd.debug` — verbose initramfs output (shows exactly where it stalls)
- Enables `rd.udev.log_level=7` and `systemd.log_level=info`
- Adds `earlyprintk=efi,keep` — captures messages before KMS loads

Works even when boot completely fails — you can read the last line on screen.

### 📝 New: `smplos-boot-log` service
When booted from a Ventoy USB and the system reaches `multi-user.target`, a oneshot systemd service:
1. Detects the Ventoy data partition by label (`Ventoy`)
2. Mounts it read-write
3. Writes `dmesg-TIMESTAMP.log` + `journal-TIMESTAMP.log` to `smplos-boot-logs/` at the root of the USB

No-op when the Ventoy partition is absent (installed system, QEMU, etc.).

### 📖 Docs: README Architecture + Building sections updated
- Architecture tree reflects actual current directory structure
- Podman is now correctly documented as the preferred runtime (daemonless, no group setup); Docker remains supported as fallback
- Fixed AUR cache path (`src/iso/prebuilt` → `build/prebuilt`)
- Fixed DNS troubleshooting (build uses `--network=host`, not `--dns` flags)
- Added `--all` edition shorthand flag
- Added build log location to "What the Build Does"