### PR TITLE
fix: avoid hyprland IgnorePkg dependency conflicts during updates

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -14,7 +14,7 @@ smplOS uses a **git-based update system**. The repo is cloned to
 3. Runs pending migrations from `migrations/`
 4. Bumps `/etc/os-release` from `src/VERSION`
 5. Reapplies the current theme + reloads Hyprland
-6. Updates system packages (Hyprland/EWW held back until after migrations)
+6. Updates system packages in one transaction (temporarily unpins Hyprland/EWW after migrations)
 7. Updates forked apps from GitHub releases
 8. Updates AUR + Flatpak packages
 
@@ -208,11 +208,15 @@ Version state is in `~/.local/state/smplos/app-versions/`.
 
 ---
 
-## 7. Pinned Packages (Hyprland, EWW)
+## 7. Hyprland/EWW Update Strategy
 
-Hyprland and EWW are held back by `IgnorePkg` in `/etc/pacman.conf`.
-This means `pacman -Syu` won't update them. They're updated explicitly
-by `smplos-update` in step 3, AFTER migrations have run.
+Many users pin Hyprland/EWW in `IgnorePkg` inside `/etc/pacman.conf`.
+`smplos-update` handles this safely by:
+
+1. Running migrations first (`smplos-os-update`)
+2. Temporarily removing `hyprland`/`eww` from `IgnorePkg`
+3. Running a single `pacman -Syu` transaction
+4. Restoring the original `/etc/pacman.conf`
 
 ### Why?
 
@@ -227,7 +231,18 @@ a migration has fixed their config — resulting in a broken desktop.
 3. Commit the migration + any updated default configs
 4. Push to `main`
 
-Users will get: migration runs → config fixed → Hyprland/EWW updates.
+Users will get: migration runs → config fixed → full pacman transaction.
+
+### Important: manual `pacman -Syu`
+
+If you run `pacman -Syu` manually while Hyprland is pinned, you can hit
+dependency conflicts (`aquamarine`/`hyprutils` ABI bumps). Use
+`smplos-update --mode full` for normal OS updates.
+
+### Hyprland config format note
+
+Hyprland still uses **Hyprlang** config files (`.conf`). There is no
+Lua migration required for normal smplOS Hyprland configs.
 
 ---
 
@@ -259,9 +274,6 @@ When a user clicks "Update OS" in app-center or runs `smplos-update --mode full`
 
 ── Pacman ──
   [standard pacman output]
-
-── Pinned packages (Hyprland, EWW) ──
-  [updates hyprland and eww]
 
 ── smplOS Apps ──
   ✓ smpl-apps: updated to v0.2.0

--- a/migrations/20260613-100000-hyprshell-no-plugin.sh
+++ b/migrations/20260613-100000-hyprshell-no-plugin.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# Migration: Suppress hyprshell "Unable to load hyprland plugin" notification
+# Context: Since Hyprland 0.55, hyprshell tries to build its plugin at runtime
+#          against the current Hyprland headers, but the build fails because
+#          of include-path mismatches in upstream Hyprland headers. Hyprshell
+#          falls back to default keybinds and Alt-Tab still works fine, but
+#          the user sees a scary notification on every boot and config reload.
+#
+#          Setting HYPRSHELL_NO_USE_PLUGIN=1 tells hyprshell to skip the plugin
+#          attempt entirely. This is the upstream-supported way to silence it.
+#          We ship this as a system-wide systemd user drop-in.
+
+set -euo pipefail
+
+DROPIN_DIR="/etc/systemd/user/hyprshell.service.d"
+DROPIN="$DROPIN_DIR/no-plugin.conf"
+
+if [[ -f "$DROPIN" ]] && grep -q "HYPRSHELL_NO_USE_PLUGIN=1" "$DROPIN"; then
+    echo "  hyprshell no-plugin drop-in already present, skipping"
+    exit 0
+fi
+
+echo "  Writing $DROPIN"
+sudo mkdir -p "$DROPIN_DIR"
+sudo tee "$DROPIN" >/dev/null << 'EOF'
+[Service]
+Environment=HYPRSHELL_NO_USE_PLUGIN=1
+EOF
+
+echo "  Reloading systemd user units"
+systemctl --user daemon-reload 2>/dev/null || true
+
+if systemctl --user is-active --quiet hyprshell.service 2>/dev/null; then
+    echo "  Restarting hyprshell"
+    systemctl --user restart hyprshell.service || true
+fi
+
+echo "  Done — the plugin warning will no longer appear"

--- a/src/compositors/hyprland/postinstall.sh
+++ b/src/compositors/hyprland/postinstall.sh
@@ -96,4 +96,14 @@ XDG_SESSION_TYPE=wayland
 XDG_SESSION_DESKTOP=Hyprland
 ENVEOF
 
+# Hyprshell: skip the runtime plugin build. Since Hyprland 0.55, hyprshell's
+# plugin fails to compile against current headers, but hyprshell falls back to
+# default keybinds and works fine without it. This drop-in suppresses the noisy
+# "Unable to load hyprland plugin" notification on every boot/config reload.
+mkdir -p /etc/systemd/user/hyprshell.service.d
+cat > /etc/systemd/user/hyprshell.service.d/no-plugin.conf << 'EOF'
+[Service]
+Environment=HYPRSHELL_NO_USE_PLUGIN=1
+EOF
+
 echo "Hyprland configuration complete!"

--- a/src/shared/bin/smplos-update
+++ b/src/shared/bin/smplos-update
@@ -5,8 +5,8 @@
 #
 # Update order (full mode):
 #   1. smplos-os-update  — git pull smplOS repo, sync scripts, run migrations
-#   2. pacman -Syu       — system packages (Hyprland/EWW skipped via IgnorePkg)
-#   3. pacman -S pinned  — update Hyprland/EWW explicitly (safe after migrations)
+#   2. pacman -Syu       — system packages (including Hyprland/EWW in one transaction)
+#      (smplos-update temporarily removes Hyprland/EWW from IgnorePkg, then restores it)
 #   4. smplos-update-apps — forked apps from GitHub (smpl-apps, st-smpl, nemo-smpl, micro)
 #   5. paru -Sua         — AUR packages
 #   6. flatpak update    — Flatpak apps
@@ -44,9 +44,40 @@ cat >> "$UPDATE_SCRIPT" << 'EOF'
 # (pacman update bumps libalpm which breaks paru -- only update these via Update OS)
 KERNEL_IGNORE="linux,linux-lts,linux-zen,linux-hardened,linux-headers,linux-lts-headers,linux-zen-headers,linux-hardened-headers,nvidia,nvidia-lts,nvidia-dkms,nvidia-utils,lib32-nvidia-utils,mesa,lib32-mesa,vulkan-radeon,lib32-vulkan-radeon,amdvlk,lib32-amdvlk,xf86-video-amdgpu,xf86-video-intel,xf86-video-nouveau,amd-ucode,intel-ucode,grub,mkinitcpio,mkinitcpio-busybox,pacman,libalpm"
 
-# Pinned packages — held back by IgnorePkg in pacman.conf so migrations run first.
-# These are updated explicitly in step 3 after smplos-os-update has run migrations.
-PINNED_PKGS="hyprland eww"
+PACMAN_CONF_BACKUP=""
+restore_pacman_conf() {
+    [[ -n "$PACMAN_CONF_BACKUP" && -f "$PACMAN_CONF_BACKUP" ]] || return 0
+    sudo cp "$PACMAN_CONF_BACKUP" /etc/pacman.conf
+    rm -f "$PACMAN_CONF_BACKUP"
+    PACMAN_CONF_BACKUP=""
+}
+
+temporarily_unpin_for_full_update() {
+    [[ "$UPDATE_MODE" == "full" ]] || return 0
+    PACMAN_CONF_BACKUP=$(mktemp /tmp/pacman.conf.smplos-update.XXXXXX)
+    sudo cp /etc/pacman.conf "$PACMAN_CONF_BACKUP"
+    sudo awk '
+    /^[[:space:]]*IgnorePkg[[:space:]]*=/ {
+        raw = $0
+        sub(/^[[:space:]]*IgnorePkg[[:space:]]*=[[:space:]]*/, "", raw)
+        n = split(raw, a, /[[:space:]]+/)
+        out = ""
+        for (i = 1; i <= n; i++) {
+            if (a[i] == "" || a[i] == "hyprland" || a[i] == "eww") {
+                continue
+            }
+            out = out (out ? " " : "") a[i]
+        }
+        if (out != "") {
+            print "IgnorePkg   = " out
+        } else {
+            print "# IgnorePkg removed by smplos-update (hyprland/eww transaction)"
+        }
+        next
+    }
+    { print }
+    ' /etc/pacman.conf | sudo tee /etc/pacman.conf >/dev/null
+}
 
 # ── Pre-authenticate sudo once ────────────────────────────────────────────────
 # Asks for the password exactly once. A background loop refreshes the credential
@@ -55,7 +86,7 @@ PINNED_PKGS="hyprland eww"
 sudo -v || { echo "ERROR: sudo authentication failed"; read -rp "Press Enter to close..."; exit 1; }
 ( while kill -0 $$ 2>/dev/null; do sudo -n -v; sleep 30; done ) &
 SUDO_KEEPALIVE_PID=$!
-trap 'kill $SUDO_KEEPALIVE_PID 2>/dev/null' EXIT
+trap 'restore_pacman_conf; kill $SUDO_KEEPALIVE_PID 2>/dev/null' EXIT
 export SMPLOS_SUDO_READY=1
 if [[ "$UPDATE_MODE" == "apps" ]]; then
     echo "══════════════════════════════════════"
@@ -79,26 +110,15 @@ if [[ "$UPDATE_MODE" == "full" ]]; then
 fi
 
 # ── Step 2: Official repos ───────────────────────────────────────────────────
-# Hyprland/EWW are in IgnorePkg so they're skipped here — updated in step 3.
 if [[ "$UPDATE_MODE" == "apps" ]]; then
     echo "── Pacman (apps only) ──"
     sudo pacman -Syu --noconfirm --ignore "$KERNEL_IGNORE"
 else
     echo "── Pacman ──"
+    temporarily_unpin_for_full_update
     sudo pacman -Syu --noconfirm
 fi
 echo
-
-# ── Step 3: Update pinned packages (Hyprland, EWW) ──────────────────────────
-# Only in full mode. These are held back by IgnorePkg so they don't update
-# in step 2 before migrations have run. Now safe to update.
-if [[ "$UPDATE_MODE" == "full" ]]; then
-    echo "── Pinned packages (Hyprland, EWW) ──"
-    # shellcheck disable=SC2086
-    sudo pacman -S --noconfirm --needed $PINNED_PKGS 2>/dev/null \
-        || echo "  (no updates available or packages not installed)"
-    echo
-fi
 
 # ── Step 4: Forked smplOS apps (GitHub releases) ────────────────────────────
 if command -v smplos-update-apps &>/dev/null; then


### PR DESCRIPTION
## Summary\n- update `smplos-update` to temporarily remove `hyprland`/`eww` from `IgnorePkg` during full updates\n- run a single `pacman -Syu` transaction after migrations, then restore `/etc/pacman.conf`\n- update `UPDATING.md` to document the transactional flow and manual `pacman -Syu` caveat\n- clarify Hyprland config remains Hyprlang (no Lua migration needed)\n\n## Why\nUsers can hit dependency conflicts when Hyprland is pinned and Arch libraries (`aquamarine`, `hyprutils`) require a newer Hyprland ABI.\n\n## Validation\n- `bash -n src/shared/bin/smplos-update`\n- local Hyprland config verification: `Hyprland --verify-config -c ~/.config/hypr/hyprland.conf` returned `config ok`